### PR TITLE
Files and build fixes for dev/test environment:

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,9 +5,57 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  PYTH_TAG: mainnet-v2.9.1
+  SERUM_TAG: v0.4.1
+  DOCKER_SERVER: docker.io
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Initialize Environment
+        run: |
+          set -eux
+          DOCKER_IMAGE="${GITHUB_REPOSITORY}:${GITHUB_REF##*/}"
+          echo "DOCKER_IMAGE=${DOCKER_IMAGE}" >> "${GITHUB_ENV}"
+
+      - name: Build Docker Image
+        run: |
+          set -eux
+
+          # GITHUB_WORKSPACE may be relative to "/".
+          cd /
+          cd "${GITHUB_WORKSPACE}"
+
+          docker build \
+            --file docker/Dockerfile \
+            --build-arg PYTH_TAG=${{ env.PYTH_TAG }} \
+            --build-arg SERUM_TAG=${{ env.SERUM_TAG }} \
+            --tag "${{ env.DOCKER_IMAGE }}" \
+            .
+
+      - name: Publish Docker Image
+        run: |
+          # Do not set -x before referencing secrets.
+          set -eu
+
+          echo "${{ secrets.DOCKER_IO_PASS }}" | docker login \
+            "${{ env.DOCKER_SERVER }}" \
+            -u "${{ secrets.DOCKER_IO_USER }}" \
+            --password-stdin
+
+          set -x
+          SRC="${{ env.DOCKER_IMAGE }}"
+          DST="${{ env.DOCKER_SERVER }}/${SRC}"
+          docker image tag "${SRC}" "${DST}"
+          docker image push "${DST}"
+
+        # Only publish if tagged as a release.
+        if: |
+          startsWith( github.ref, 'refs/tags/devnet-' )
+          || startsWith( github.ref, 'refs/tags/testnet-' )
+          || startsWith( github.ref, 'refs/tags/mainnet-' )

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+*.swp
 build
+debug
 target
+cmake-build-*
+Cargo.lock
+/venv

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeSharedSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Debug" ENABLED="true" CONFIG_NAME="Debug" />
+      <configuration PROFILE_NAME="Release" ENABLED="true" CONFIG_NAME="Release" />
+      <configuration PROFILE_NAME="BPF" ENABLED="true" CONFIG_NAME="Release" GENERATION_OPTIONS="-DSOLANA=$CMakeProjectParentDir$/solana -DPC=$CMakeProjectParentDir$/pyth-client" />
+    </configurations>
+  </component>
+</project>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,61 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="OTHER_INDENT_OPTIONS">
+      <value>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </value>
+    </option>
+    <Objective-C>
+      <option name="INDENT_NAMESPACE_MEMBERS" value="2" />
+      <option name="INDENT_C_STRUCT_MEMBERS" value="2" />
+      <option name="INDENT_CLASS_MEMBERS" value="2" />
+      <option name="INDENT_INSIDE_CODE_BLOCK" value="2" />
+    </Objective-C>
+    <codeStyleSettings language="JSON">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Makefile">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Markdown">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="ObjectiveC">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Python">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Rust">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,10 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/serum-pyth.iml" filepath="$PROJECT_DIR$/.idea/serum-pyth.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/runConfigurations/All_Tests.xml
+++ b/.idea/runConfigurations/All_Tests.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All Tests" type="CTestRunConfiguration" factoryName="CTestRun" nameIsGenerated="true" PROGRAM_PARAMS="--extra-verbose" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$CMakeCurrentLocalGenerationDir$" PASS_PARENT_ENVS_2="true" CONFIG_NAME="BPF" RUN_PATH="$CTestCurrentExecutableName$" EXPLICIT_BUILD_TARGET_NAME="all" TEST_MODE="PATTERN">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+      <option name="BeforeTestRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/serum-pyth.iml
+++ b/.idea/serum-pyth.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required( VERSION 3.13 )
+
+project( serum-pyth )
+add_subdirectory( test-crank )
+
+function( add_bpf_lib targ )
+  if( SOLANA AND NOT BPF )
+    set( BPF ${SOLANA}/sdk/bpf )
+  endif()
+  if( BPF )
+    if( NOT PC )
+      set( PC ../pyth-client )
+    endif()
+    add_library( ${targ} STATIC ${ARGN} )
+    target_compile_definitions( ${targ} PRIVATE __bpf__=1 )
+    target_include_directories( ${targ} PRIVATE ${PC}/program/src )
+    target_include_directories( ${targ} SYSTEM PRIVATE
+      ${BPF}/c/inc
+      ${BPF}/dependencies/criterion/include
+    )
+  endif()
+endfunction()
+
+add_bpf_lib( serum-pyth program/src/serum-pyth/serum-pyth.c )
+add_bpf_lib( test-serum-pyth program/src/serum-pyth/test_serum-pyth.c )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,44 @@
+ARG PYTH_TAG
+
+# https://github.com/pyth-network/pyth-client/blob/main/docker/Dockerfile
+FROM pythfoundation/pyth-client:${PYTH_TAG}
+
+# Redeclare PYTH_TAG in the new build stage.
+# Persist in env for docker run & inspect.
+ARG PYTH_TAG
+ENV PYTH_TAG="${PYTH_TAG}"
+
+# May be https://github.com/Bonfida/serum-dex.git or another fork.
+ARG SERUM_URL="https://github.com/project-serum/serum-dex.git"
+ARG SERUM_TAG
+
+USER pyth
+WORKDIR /home/pyth
+COPY --chown=pyth:pyth . serum-pyth/
+
+# https://github.com/solana-labs/solana/issues/21198
+RUN sed -i \
+  's/\(^uint64_t sol_invoke_signed_c(\)/__attribute__(( weak )) \1/g' \
+  solana/sdk/bpf/c/inc/solana_sdk.h
+
+# Install serum-dex dependencies from:
+# https://github.com/Bonfida/serum-dex/blob/master/docker/development/Dockerfile
+RUN sudo apt-get install -qq \
+  build-essential \
+  jq \
+  pkg-config \
+  python3-pip
+
+# Clone and build serum-dex for solana-test-validator.
+RUN git clone \
+  --depth 1 \
+  --branch "${SERUM_TAG}" \
+  "${SERUM_URL}" \
+  serum-dex
+
+RUN ./pyth-client/scripts/build.sh serum-pyth/build
+RUN ./serum-pyth/scripts/build-bpf.sh serum-pyth/program
+RUN ./serum-pyth/scripts/build-dex.sh
+
+ENTRYPOINT []
+CMD []

--- a/program/src/serum-pyth/serum-pyth.c
+++ b/program/src/serum-pyth/serum-pyth.c
@@ -89,7 +89,7 @@ extern uint64_t entrypoint(const uint8_t* input)
         price->type_ != PC_ACCTYPE_PRICE ||
         price->ptype_ != PC_PTYPE_PRICE)
       return ERROR_INVALID_ACCOUNT_DATA;
-    pyth_exponent = -1 * price->expo_;
+    pyth_exponent = (__typeof__(pyth_exponent)) (-1 * price->expo_);
     if (pyth_exponent >= SOL_ARRAY_SIZE(TEN_TO_THE))
       return ERROR_INVALID_ACCOUNT_DATA;
   }

--- a/program/src/serum-pyth/serum-pyth.h
+++ b/program/src/serum-pyth/serum-pyth.h
@@ -155,3 +155,18 @@ static bool trim_serum_padding(uint8_t** iter, uint64_t* left)
 
   return true;
 }
+
+// --- serum-pyth -------------------------------------------------------------
+
+// CI is half the bid-ask spread, adjusted for the best aggressive fee.
+// https://docs.pyth.network/publishers/confidence-interval-and-crypto-exchange-fees
+// spread = ask_adjusted - bid_adjusted
+//   = ask * (1.0 + fee) - bid * (1.0 - fee)
+//   = (ask - bid) + (ask + bid) * fee
+static inline uint64_t get_confidence(const uint64_t bid, const uint64_t ask)
+{
+  const uint64_t fee_bps = 10UL;  // TODO Read from config or serum API
+  uint64_t spread = (bid < ask) ? (ask - bid) : (bid - ask);
+  spread += (bid + ask) * fee_bps / 10000UL;
+  return spread / 2;
+}

--- a/program/src/serum-pyth/test_serum-pyth.c
+++ b/program/src/serum-pyth/test_serum-pyth.c
@@ -1,0 +1,19 @@
+char heap_start[8192];
+#define PC_HEAP_START (heap_start)
+#include "serum-pyth.c"
+#include <criterion/criterion.h>
+
+#define sp_expect_eq(act, exp, fmt) \
+  cr_expect_eq(act, exp, "expected " fmt ", got " fmt, exp, act)
+
+#define sp_expect_uint(act, exp) \
+  sp_expect_eq(act, exp, "%lu")
+
+Test(serum_pyth, confidence) {
+
+  // https://docs.pyth.network/publishers/confidence-interval-and-crypto-exchange-fees
+  // bid=$50,000.000, ask=$50,000.010, fee=10bps -> CI=$50.005
+  sp_expect_uint(get_confidence(50000000, 50000010), 50005ul);
+  sp_expect_uint(get_confidence(50000010, 50000000), 50005ul);
+
+}

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Build given bpf makefile dir (./program by default):
+#   ~/pyth-client$ ./scripts/build-bpf.sh
+#   ~/pyth-client/program$ ../scripts/build-bpf.sh .
+#   ~/$ ./pyth-client/scripts/build-bpf.sh ./serum-pyth/program
+#
+
+set -eu
+
+BUILD_DIR="$( cd "${1:-program}" && pwd )"
+
+if [[ ! -f "${BUILD_DIR}/makefile" ]]
+then
+  >&2 echo "Not a makefile dir: ${BUILD_DIR}"
+  exit 1
+fi
+
+if ! which cargo 2> /dev/null
+then
+  # shellcheck disable=SC1090
+  source "${CARGO_HOME:-$HOME/.cargo}/env"
+fi
+
+set -x
+
+cd "${BUILD_DIR}"
+make V=1 clean
+make V=1 "${@:2}"
+sha256sum ../target/*.so

--- a/scripts/build-dex.sh
+++ b/scripts/build-dex.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [[ ! -v SERUM_DEX ]]
+then
+  _THIS_DIR="$( dirname "${BASH_SOURCE[0]}" )"
+  SERUM_DEX="$( cd "${_THIS_DIR}/../.." && pwd )/serum-dex"
+fi
+
+if ! which cargo 2> /dev/null
+then
+  # shellcheck disable=SC1090
+  source "${CARGO_HOME:-$HOME/.cargo}/env"
+fi
+
+set -x
+cd "${SERUM_DEX}/dex"
+cargo +bpf build "$@"
+sha256sum -b target/*/*/*.so

--- a/test-crank/CMakeLists.txt
+++ b/test-crank/CMakeLists.txt
@@ -1,8 +1,8 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.19.2)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.13)
 
 PROJECT(serum-pyth-crank)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_COMPILER g++)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -17,6 +17,8 @@ FIND_PACKAGE(OpenSSL REQUIRED)
 TARGET_INCLUDE_DIRECTORIES(serum-pyth-crank PRIVATE ../../pyth-client/)
 TARGET_INCLUDE_DIRECTORIES(serum-pyth-crank PRIVATE ../../pyth-client/program/src/)
 
-FIND_LIBRARY(L_PC libpc.a "../../pyth-client/build/libpc.a")
+FIND_LIBRARY(L_PC libpc.a ../../pyth-client/build)
 
 TARGET_LINK_LIBRARIES(serum-pyth-crank PRIVATE ${L_PC} OpenSSL::SSL OpenSSL::Crypto pthread z zstd)
+
+ENABLE_TESTING()


### PR DESCRIPTION
- Add `test_serum-pyth.c` with initial test for `get_confidence`.
- Add `Dockerfile`, `.github/workflow`, and build scripts.
- Add `.idea/` with CLion settings.
- Add project-level `CMakeLists.txt` with fake bpf target for CLion.
- Reduce `test-crank`'s requirements for cmake version and C++ standard.
- Cast `pyth_exponent` to fix implicit conversion warning (TODO check for overflow).