### PR TITLE
Add threshold for confidence that sets status to unknown

### DIFF
--- a/program/src/serum-pyth/serum-pyth.c
+++ b/program/src/serum-pyth/serum-pyth.c
@@ -269,7 +269,7 @@ static inline sp_errcode_t sp_get_pyth_instruction(
       // Safe as long as threshold_conf isn't the min int64, which it isn't as long as PRICE_CONF_THRESHOLD > 1.
       threshold_conf = -threshold_conf;
     }
-    if ( pyth_conf > threshold_conf ) {
+    if ( pyth_conf > (uint64_t) threshold_conf ) {
       trading = false;
     }
   }

--- a/program/src/serum-pyth/sp-util.h
+++ b/program/src/serum-pyth/sp-util.h
@@ -53,6 +53,10 @@ static const sp_expo_t SP_EXP_MAX = SOL_ARRAY_SIZE( SP_POW10 ) - 1;
 static const sp_size_t SP_SIZE_OVERFLOW = UINT64_MAX;
 static const sp_size_t SP_SIZE_MAX = SP_SIZE_OVERFLOW - 1;
 
+// The feed's status will be unknown if conf > (price / this value).
+// e.g. 20 means the confidence interval is at most 5% of the price.
+static const int64_t PRICE_CONF_THRESHOLD = 20;
+
 // Calculate 10^exp * numer / denom
 static inline sp_size_t sp_pow10_divide(
   sp_size_t numer,


### PR DESCRIPTION
Serum markets can occasionally have rather wide bid/offer spreads. Set the status to unknown if the spread is too large, as the serum market conveys little pricing information in that case.